### PR TITLE
Feat: サブネットの作成

### DIFF
--- a/modules/vpc/availability_zones.tf
+++ b/modules/vpc/availability_zones.tf
@@ -1,0 +1,9 @@
+data "aws_availability_zones" "availability_zones" {
+  state = "available"
+
+  exclude_names = ["ap-northeast-1b"]
+}
+
+locals {
+  number_of_availability_zones = length(data.aws_availability_zones.availability_zones.names)
+}

--- a/modules/vpc/igw.tf
+++ b/modules/vpc/igw.tf
@@ -1,0 +1,11 @@
+resource "aws_internet_gateway" "igw" {
+  vpc_id = aws_vpc.vpc.id
+  tags = merge(
+    var.igw_additional_tags,
+    {
+      Name  = "${var.service_name}-${var.env}-igw"
+      Env   = var.env
+      VpcId = aws_vpc.vpc.id
+    }
+  )
+}

--- a/modules/vpc/nat_gateway.tf
+++ b/modules/vpc/nat_gateway.tf
@@ -1,0 +1,25 @@
+locals {
+  from_az_to_public_subnet_id = { for cidr in keys(aws_subnet.public_subnets) : aws_subnet.public_subnets[cidr].tags["AvailabilityZone"] => aws_subnet.public_subnets[cidr].id }
+}
+
+resource "aws_eip" "eips" {
+  for_each = local.from_az_to_public_subnet_id
+
+  tags = {
+    Name             = "${var.service_name}-${var.env}-eip-${each.key}-eip"
+    AvailabilityZone = each.key
+    Usage            = "NAT"
+  }
+}
+
+resource "aws_nat_gateway" "nat_gateways" {
+  for_each = local.from_az_to_public_subnet_id
+  # Elastic IP アドレスを指定
+  allocation_id = aws_eip.eips[each.key].allocation_id
+  subnet_id     = each.value
+
+  tags = {
+    Name             = "${var.service_name}-${var.env}-${each.key}-nat-gateway"
+    AvailabilityZone = each.key
+  }
+}

--- a/modules/vpc/outputs.tf
+++ b/modules/vpc/outputs.tf
@@ -7,3 +7,23 @@ output "vpc_name" {
   description = "作成したVPCの名前です"
   value       = aws_vpc.vpc.tags["Name"]
 }
+
+output "public_subnets" {
+  description = "パブリックサブネットの情報です"
+  value       = { for subnet in aws_subnet.public_subnets : subnet.availability_zone => subnet.id }
+}
+
+output "private_subnets" {
+  description = "プライベートサブネットの情報です"
+  value       = { for subnet in aws_subnet.private_subnets : subnet.availability_zone => subnet.id }
+}
+
+output "public_route_tables" {
+  description = "パブリックサブネットのルートテーブル情報です"
+  value       = { for route_table in aws_route_table.public_route_tables : route_table.tags["AvailabilityZone"] => route_table.id }
+}
+
+output "private_route_tables" {
+  description = "プライベートサブネットのルートテーブル情報です"
+  value       = { for route_table in aws_route_table.private_route_tables : route_table.tags["AvailabilityZone"] => route_table.id }
+}

--- a/modules/vpc/route_tables.tf
+++ b/modules/vpc/route_tables.tf
@@ -1,0 +1,60 @@
+# aws_route_table : VPC内のルートテーブル自体を作成
+# aws_route : ルートテーブルに対して、どこに通信を送るかというルートを追加
+# aws_route_table_association : どのサブネットが、どのルートテーブルを使うかを明示的に指定
+
+# パブリックサブネット用のルートテーブル
+resource "aws_route_table" "public_route_tables" {
+  for_each = aws_subnet.public_subnets
+  vpc_id   = aws_vpc.vpc.id
+
+  tags = {
+    Name             = "${var.service_name}-${var.env}-${each.value.availability_zone}-public-route-table"
+    AvailabilityZone = each.value.availability_zone
+    Scope            = "public"
+  }
+}
+
+# パブリックサブネットのデフォルトルート
+resource "aws_route" "public_default_route" {
+  for_each       = aws_subnet.public_subnets
+  route_table_id = aws_route_table.public_route_tables[each.key].id
+
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.igw.id
+}
+
+# パブリックサブネットとパブリックサブネット用のルートテーブルのひも付け
+resource "aws_route_table_association" "public_route_table_associations" {
+  for_each       = aws_subnet.public_subnets
+  route_table_id = aws_route_table.public_route_tables[each.key].id
+  subnet_id      = each.value.id
+}
+
+# プライベートサブネット用のルートテーブル
+resource "aws_route_table" "private_route_tables" {
+  for_each = aws_subnet.private_subnets
+  vpc_id   = aws_vpc.vpc.id
+
+  tags = {
+    Name             = "${var.service_name}-${var.env}-${each.value.availability_zone}-private-route-table"
+    AvailabilityZone = each.value.availability_zone
+    Scope            = "private"
+  }
+}
+
+# プライベートサブネット用のデフォルトルート設定
+resource "aws_route" "private_default_route" {
+  for_each       = aws_subnet.private_subnets
+  route_table_id = aws_route_table.private_route_tables[each.key].id
+
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = aws_nat_gateway.nat_gateways[each.value.availability_zone].id
+}
+
+# プライベートサブネットとプライベートサブネット用のルートテーブルのひも付け
+resource "aws_route_table_association" "private_route_table_associations" {
+  for_each       = aws_subnet.private_subnets
+  route_table_id = aws_route_table.private_route_tables[each.key].id
+  subnet_id      = each.value.id
+}
+

--- a/modules/vpc/subnets.tf
+++ b/modules/vpc/subnets.tf
@@ -1,0 +1,37 @@
+resource "aws_subnet" "public_subnets" {
+  for_each   = toset(var.subnet_cidrs.public)
+  cidr_block = each.key
+  vpc_id     = aws_vpc.vpc.id
+
+  availability_zone = data.aws_availability_zones.availability_zones.names[
+    index(var.subnet_cidrs.public, each.key) % local.number_of_availability_zones
+  ]
+
+  tags = merge(
+    var.subnet_additional_tags,
+    {
+      Name             = "${var.service_name}-${var.env}-${data.aws_availability_zones.availability_zones.names[index(var.subnet_cidrs.public, each.key) % local.number_of_availability_zones]}-public-subnet"
+      Env              = var.env
+      Scope            = "public"
+      AvailabilityZone = data.aws_availability_zones.availability_zones.names[index(var.subnet_cidrs.public, each.key) % local.number_of_availability_zones]
+    }
+  )
+}
+
+resource "aws_subnet" "private_subnets" {
+  for_each   = toset(var.subnet_cidrs.private)
+  cidr_block = each.key
+  vpc_id     = aws_vpc.vpc.id
+
+  availability_zone = data.aws_availability_zones.availability_zones.names[index(var.subnet_cidrs.private, each.key) % local.number_of_availability_zones]
+
+  tags = merge(
+    var.subnet_additional_tags,
+    {
+      Name             = "${var.service_name}-${var.env}-${data.aws_availability_zones.availability_zones.names[index(var.subnet_cidrs.private, each.key) % local.number_of_availability_zones]}-private-subnet"
+      Env              = var.env
+      Scope            = "private"
+      AvailabilityZone = data.aws_availability_zones.availability_zones.names[index(var.subnet_cidrs.private, each.key) % local.number_of_availability_zones]
+    }
+  )
+}

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -10,13 +10,13 @@ variable "vpc_cidr_block" {
 }
 
 variable "service_name" {
-  type        = string
   description = "VPCを利用するサービス名"
+  type        = string
 }
 
 variable "env" {
-  type        = string
   description = "環境識別子（dev, stg, prod）"
+  type        = string
 }
 
 variable "vpc_additional_tags" {
@@ -33,5 +33,67 @@ variable "vpc_additional_tags" {
         )
     ) == 0)
     error_message = "key names, Name and Env is reserved. Not allowed to use them"
+  }
+}
+
+variable "subnet_cidrs" {
+  description = "サブネットごとのCIDR指定"
+  type = object({
+    public  = list(string)
+    private = list(string)
+  })
+
+  # CIDRフォーマットのバリデーション
+  validation {
+    condition = length(setintersection([
+      for cidr in var.subnet_cidrs.public : (can(
+        regex("^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}/\\d{1,2}$", cidr)
+      ) ? cidr : null)
+    ], var.subnet_cidrs.public)) == length(var.subnet_cidrs.public)
+    error_message = "Specify VPC Public Subnet CIDR blocks with the CIDR format"
+  }
+  validation {
+    condition = length(setintersection([
+      for cidr in var.subnet_cidrs.private : (can(
+        regex("^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}/\\d{1,2}$", cidr)
+      ) ? cidr : null)
+    ], var.subnet_cidrs.private)) == length(var.subnet_cidrs.private)
+    error_message = "Specify VPC Private Subnet CIDR blocks with the CIDR format."
+  }
+
+  # 可用性的な観点でのバリデーション
+  validation {
+    condition     = length(var.subnet_cidrs.public) >= 2
+    error_message = "For availability, set more than 2 public subnet cidrs."
+  }
+  validation {
+    condition     = length(var.subnet_cidrs.private) >= 2
+    error_message = "For availability, set more than 2 private subnet cidrs."
+  }
+
+  # publicとprivateの配列長が同じことを確認するバリデーション
+  validation {
+    condition     = length(var.subnet_cidrs.public) == length(var.subnet_cidrs.private)
+    error_message = "Redundancy of public subnet and private subnet must be same."
+  }
+}
+
+variable "subnet_additional_tags" {
+  description = "サブネットに付与したい追加タグ（Name, Env, AvailabilityZone, Scope 除く）"
+  type        = map(string)
+  default     = {}
+  validation {
+    condition     = length(setintersection(keys(var.subnet_additional_tags), ["Name", "Env", "AvailabilityZone", "Scope"])) == 0
+    error_message = "Key names, Name and Env, AvailabilityZone, Scope are reserved. Not allowed to use them."
+  }
+}
+
+variable "igw_additional_tags" {
+  description = "インターネットゲートウェイに付与したい追加タグ（Name, Env, VpcId 除く）"
+  type        = map(string)
+  default     = {}
+  validation {
+    condition     = length(setintersection(keys(var.igw_additional_tags), ["Name", "Env", "VpcId"])) == 0
+    error_message = "Key names, Name and Env, VpcId are reserved. Not allowed to use them."
   }
 }

--- a/resources.tf
+++ b/resources.tf
@@ -6,4 +6,8 @@ module "vpc" {
   vpc_additional_tags = {
     Usage = "sample vpc explanation"
   }
+  subnet_cidrs = {
+    public  = ["10.0.1.0/24", "10.0.2.0/24"]
+    private = ["10.0.101.0/24", "10.0.102.0/24"]
+  }
 }


### PR DESCRIPTION
## 概要

- VPCに各種リソースを配置するために必要なサブネットを作成。
- VPCとインターネット間の接続のため、インターネットゲートウェイをVPCに割り当て。
- サブネットを直接インターネット通信が可能なパブリックサブネットと、そうでないプライベートサブネットに分けて定義。
- プライベートサブネットはインターネットと直接通信はせずに、パブリックサブネットに配置したNATゲートウェイ経由で通信する。