### PR TITLE
Feat: ecrのrepositoryとlifecycle policyの追加

### DIFF
--- a/modules/ecr/ecr.tf
+++ b/modules/ecr/ecr.tf
@@ -1,0 +1,9 @@
+resource "aws_ecr_repository" "repository" {
+  name                 = "${var.service_name}-${var.env}-${var.role}"
+  image_tag_mutability = var.image_tag_mutability
+}
+
+resource "aws_ecr_lifecycle_policy" "policy" {
+  repository = aws_ecr_repository.repository.name
+  policy     = var.repository_lifecycle_policy == "" ? file("${path.module}/lifecycle_policy/default_policy.json") : var.repository_lifecycle_policy
+}

--- a/modules/ecr/lifecycle_policy/default_policy.json
+++ b/modules/ecr/lifecycle_policy/default_policy.json
@@ -1,0 +1,17 @@
+{
+    "rules": [
+      {
+        "rulePriority": 1,
+        "description": "Expire untagged images older than 30 days",
+        "selection": {
+          "tagStatus": "untagged",
+          "countType": "sinceImagePushed",
+          "countUnit": "days",
+          "countNumber": 30
+        },
+        "action": {
+          "type": "expire"
+        }
+      }
+    ]
+}

--- a/modules/ecr/variables.tf
+++ b/modules/ecr/variables.tf
@@ -1,0 +1,54 @@
+variable "service_name" {
+  description = "サービス名"
+  type        = string
+}
+
+variable "env" {
+  description = "環境識別子（dev, stg, prod）"
+  type        = string
+}
+
+variable "role" {
+  description = "リポジトリに格納するイメージのサービス内でのロール"
+  type        = string
+}
+
+variable "image_tag_mutability" {
+  description = <<DESC
+  タグの上書きを許容するか否かを指定します。
+  - `MUTABLE` 上書き可能
+  - `IMMUTABLE` 上書き不可
+  DESC
+  type        = string
+  default     = "MUTABLE"
+}
+
+variable "repository_lifecycle_policy" {
+  description = <<DESC
+  リポジトリのライフサイクルポリシーをjson形式で指定します。デフォルト値を指定した場合は、
+  タグのないイメージのうちプッシュから30日以上経過したイメージを削除します。
+  具体的な記述内容は`lifecycle_policy/default_policy.json` を参照してください。
+  参考：https://docs.aws.amazon.com/ja_jp/AmazonECR/latest/userguide/LifecyclePolicies.html
+  DESC
+  type        = string
+  default     = <<DEFAULT
+  {
+    "rules": [
+      {
+        "rulePriority": 1,
+        "description": "Expire untagged images older than 30 days",
+        "selection": {
+          "tagStatus": "untagged",
+          "countType": "sinceImagePushed",
+          "countUnit": "days",
+          "countNumber": 30
+        },
+        "action": {
+          "type": "expire"
+        }
+      }
+    ]
+  }
+DEFAULT
+}
+


### PR DESCRIPTION
This pull request introduces a new reusable Terraform module for managing AWS ECR repositories, including support for custom lifecycle policies and configurable repository settings. The module allows users to specify service name, environment, role, image tag mutability, and lifecycle policies, with sensible defaults provided.

**ECR repository and lifecycle policy module:**

* Added `aws_ecr_repository` and `aws_ecr_lifecycle_policy` resources to `ecr.tf`, allowing creation of ECR repositories with configurable names and lifecycle policies. The lifecycle policy defaults to deleting untagged images older than 30 days but can be overridden by the user.
* Added a default lifecycle policy JSON file (`lifecycle_policy/default_policy.json`) that expires untagged images older than 30 days, referenced by the module if no custom policy is provided.

**Module configuration and documentation:**

* Introduced variables in `variables.tf` for `service_name`, `env`, `role`, `image_tag_mutability`, and `repository_lifecycle_policy`, each with descriptions (in Japanese) and appropriate defaults, making the module flexible and self-documenting.<!-- I want to review in Japanese. -->

## 概要
<!-- 作業内容を記載して下さい -->
-

<!-- for GitHub Copilot review rule -->
<!--
レビューする際には、以下のprefix(接頭辞)をつけてください
[must]  
[imo] (in my opinion)  
[nits](nitpick) 
[ask]  
[fyi]
-->
<!-- for GitHub Copilot review  rule-->

<!-- I want to review in Japanese. -->